### PR TITLE
Fixing token approle renew to use renew-self

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ $ docker run -d \
   --name=drone-vault drone/vault
 ```
 
+Using approle authentication:
+
+```text
+$ docker run -d \
+  --publish=3000:3000 \
+  --env=DRONE_DEBUG=true \
+  --env=DRONE_SECRET=bea26a2221fd8090ea38720fc445eca6 \
+  --env=VAULT_ADDR=... \
+  --env=VAULT_AUTH_TYPE=approle \
+  --env=VAULT_TOKEN_TTL=72h
+  --env=VAULT_TOKEN_RENEWAL=24h
+  --env=VAULT_APPROLE_ID=... \
+  --env=VAULT_APPROLE_SECRET=... \
+  --restart=always \
+  --name=drone-vault drone/vault
+```
+
 Update your runner configuration to include the plugin address and the shared secret.
 
 ```text

--- a/plugin/token/approle/approle.go
+++ b/plugin/token/approle/approle.go
@@ -41,7 +41,7 @@ func NewRenewer(client *api.Client, roleId string, secretId string, ttl time.Dur
 // Renew renews the Vault token.
 func (r *Renewer) Renew(ctx context.Context) error {
 	// create the vault endpoint address.
-	path := "auth/token/renew"
+	path := "auth/token/renew-self"
 
 
 	if r.client.Token() == "" {
@@ -55,11 +55,10 @@ func (r *Renewer) Renew(ctx context.Context) error {
 
 	resp, err := r.client.Logical().Write(path,
 		map[string]interface{}{
-			"token": r.client.Token(),
 			"increment": strconv.Itoa(r.ttl),
 		})
 	if err != nil {
-		logrus.Warnln("vault approle: token could not be renewed")
+		logrus.WithError(err).Errorln("vault approle: token could not be renewed")
 		return r.NewToken(ctx)
 	}
 
@@ -86,7 +85,7 @@ func (r *Renewer) Renew(ctx context.Context) error {
 	ttl := time.Duration(resp.Auth.LeaseDuration) * time.Second
 
 	logrus.WithField("ttl", ttl).
-	 	Debugln("approle: token received")
+	 	Debugln("vault approle: existing token valid")
 
 	return nil
 }
@@ -121,7 +120,7 @@ func (r *Renewer) NewToken(ctx context.Context) error {
 	r.client.SetToken(resp.Auth.ClientToken)
 	ttl := time.Duration(resp.Auth.LeaseDuration) * time.Second
 	logrus.WithField("ttl", ttl).
-		Debugln("approle: token received")
+		Debugln("vault approle: token received")
 
 	return nil
 }

--- a/plugin/token/approle/approle_test.go
+++ b/plugin/token/approle/approle_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 // Renew an existing token
 func TestVaultApproleRenew(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/v1/auth/token/renew" {
+		if r.URL.Path != "/v1/auth/token/renew-self" {
 			t.Errorf("Invalid path, %v", r.URL.Path)
 		}
 		data, _ := ioutil.ReadFile("testdata/renew_token.json")
@@ -125,7 +125,7 @@ func TestVaultApproleNewToken(t *testing.T) {
 func TestVaultApproleRenewHigherTTL(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var data []byte
-		if r.URL.Path == "/v1/auth/token/renew" {
+		if r.URL.Path == "/v1/auth/token/renew-self" {
 			data, _ = ioutil.ReadFile("testdata/renew_higher_ttl.json")
 		} else if r.URL.Path == "/v1/auth/approle/login" {
 			data, _ = ioutil.ReadFile("testdata/new_token.json")
@@ -160,7 +160,7 @@ func TestVaultApproleRenewHigherTTL(t *testing.T) {
 func TestVaultApproleRenewLowerTTL(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var data []byte
-		if r.URL.Path == "/v1/auth/token/renew" {
+		if r.URL.Path == "/v1/auth/token/renew-self" {
 			data, _ = ioutil.ReadFile("testdata/renew_lower_ttl.json")
 		} else if r.URL.Path == "/v1/auth/approle/login" {
 			data, _ = ioutil.ReadFile("testdata/new_token.json")


### PR DESCRIPTION
My local testing had used a token that had admin perms.  This causes issues with tokens that try and access /auth/token/renew.  By default tokens only have access to /auth/token/renew-self, so switching to that rest method.  Also adding a README section for `approle` usage and updating a few log statements