### PR TITLE
Case Insensitive Match

### DIFF
--- a/plugin/match.go
+++ b/plugin/match.go
@@ -23,3 +23,12 @@ func match(name string, patterns []string) bool {
 	}
 	return false
 }
+
+func matchCaseInsensitive(name string, params map[string]string) (string, bool) {
+	for key, value := range params {
+		if strings.ToLower(key) == strings.ToLower(name) {
+			return value, true
+		}
+	}
+	return "", false
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -39,7 +39,7 @@ func (p *plugin) Find(ctx context.Context, req *secret.Request) (*drone.Secret, 
 	if err != nil {
 		return nil, errors.New("secret not found")
 	}
-	value, ok := params[name]
+	value, ok := matchCaseInsensitive(name, params)
 	if !ok {
 		return nil, errors.New("secret key not found")
 	}

--- a/plugin/testdata/uppercase_secret.json
+++ b/plugin/testdata/uppercase_secret.json
@@ -1,0 +1,13 @@
+{
+  "data": {
+    "Username": "david",
+    "password": "BnQw&XDWgaEeT9XGTT29",
+    "X-Drone-Repos":"octocat/*",
+    "X-Drone-Events":"tag,push",
+    "X-Drone-Branches":"master",
+    "timestmap": 2764800
+  },
+  "lease_duration": 2764800,
+  "renewable": false,
+  "request_id": "5e246671-ec05-6fc8-9f93-4fe4512f34ab"
+}


### PR DESCRIPTION
### **Description**
The following pull request corrects an issue where pulling secrets from Vault fails due to case-sensitive key referencing. At a high level, this issue means that an attempt by Drone to pull "username" when the key in Vault is "Username" will result in a "secret key not found" error.

### **Use Case**
Lets assume we are attempting to pull a secret in vault which has the key "FOO" and value "BAR".

- Example pipeline yaml pulling secret "foo"
```
---

kind: secret
name: foo
get:
    path: example/data/credentials
    name: foo
```
- Currently, the plugin will processes this request and make a found/not found decision based on the line of code [here](https://github.com/drone/drone-vault/blob/9e5d97d33727fc59b94ca6773af51645ff9a58e5/plugin/plugin.go#L42). This operation does not account for mismatched case. Searching the params map for "foo" will yield no results (actual key in Vault stored as "FOO"), and as such the pipeline will return "secret key not found".

### **How To Fix This Issue**
This issue can be fixed by performing a case-insensitive key lookup when querying the secret value from the "params" go map. The code changes proposed successfully mitigate this issue.

For testing purposes I have included a new unit test [uppercase_secret.json](https://github.com/ExpressScripts/drone-vault/blob/case-insensitive-match/plugin/testdata/uppercase_secret.json) which tests successfully pulling a secret when drone requests the value for [key="USERNAME"](https://github.com/ExpressScripts/drone-vault/blob/dc339cbe5d2c46b77fbdcc70faaf8da1583e849e/plugin/plugin_test.go#L260) and Vault includes a record where [key="Username"](https://github.com/ExpressScripts/drone-vault/blob/dc339cbe5d2c46b77fbdcc70faaf8da1583e849e/plugin/testdata/uppercase_secret.json#L3).

### **Additional Considerations**
I could not think of any example/reason where a request for "USERNAME" when Vault is storing the key as "Username" would cause unintended consequences or impact. A secret in the form of a key/value pair should be represented with a unique key, therefor IMO "username" and "Username" should not be treated as separate values.