### PR TITLE
Convert data types to string instead of skipping

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,9 +5,8 @@ name: default
 
 steps:
 - name: build
-  image: golang:1.12
+  image: golang:1.17
   commands:
-  - apt update && apt install ca-certificates libgnutls30 -y
   - go test -v ./...
   - sh scripts/build.sh
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,7 @@ steps:
 - name: build
   image: golang:1.12
   commands:
+  - apt update && apt install ca-certificates libgnutls30 -y
   - go test -v ./...
   - sh scripts/build.sh
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -7,6 +7,8 @@ package plugin
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
 
 	"github.com/drone/drone-go/drone"
 	"github.com/drone/drone-go/plugin/secret"
@@ -95,11 +97,37 @@ func (p *plugin) find(path string) (map[string]string, error) {
 	}
 
 	params := map[string]string{}
-	for k, v := range secret.Data {
-		s, ok := v.(string)
-		if !ok {
-			continue
+	for k, rawValue := range secret.Data {
+		var s string
+		switch castValue := rawValue.(type) {
+		case bool:
+			s = strconv.FormatBool(castValue)
+		case string:
+			s = castValue
+		case int:
+			s = strconv.FormatInt(int64(castValue), 10)
+		case int8:
+			s = strconv.FormatInt(int64(castValue), 10)
+		case int16:
+			s = strconv.FormatInt(int64(castValue), 10)
+		case int32:
+			s = strconv.FormatInt(int64(castValue), 10)
+		case int64:
+			s = strconv.FormatInt(int64(castValue), 10)
+		case uint:
+			s = strconv.FormatUint(uint64(castValue), 10)
+		case uint8:
+			s = strconv.FormatUint(uint64(castValue), 10)
+		case uint16:
+			s = strconv.FormatUint(uint64(castValue), 10)
+		case uint32:
+			s = strconv.FormatUint(uint64(castValue), 10)
+		case uint64:
+			s = strconv.FormatUint(uint64(castValue), 10)
+		default:
+			s = fmt.Sprintf("%v", castValue)
 		}
+
 		params[k] = s
 	}
 	return params, err

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 
 	"github.com/drone/drone-go/drone"
 	"github.com/drone/drone-go/plugin/secret"
@@ -97,38 +96,8 @@ func (p *plugin) find(path string) (map[string]string, error) {
 	}
 
 	params := map[string]string{}
-	for k, rawValue := range secret.Data {
-		var s string
-		switch castValue := rawValue.(type) {
-		case bool:
-			s = strconv.FormatBool(castValue)
-		case string:
-			s = castValue
-		case int:
-			s = strconv.FormatInt(int64(castValue), 10)
-		case int8:
-			s = strconv.FormatInt(int64(castValue), 10)
-		case int16:
-			s = strconv.FormatInt(int64(castValue), 10)
-		case int32:
-			s = strconv.FormatInt(int64(castValue), 10)
-		case int64:
-			s = strconv.FormatInt(int64(castValue), 10)
-		case uint:
-			s = strconv.FormatUint(uint64(castValue), 10)
-		case uint8:
-			s = strconv.FormatUint(uint64(castValue), 10)
-		case uint16:
-			s = strconv.FormatUint(uint64(castValue), 10)
-		case uint32:
-			s = strconv.FormatUint(uint64(castValue), 10)
-		case uint64:
-			s = strconv.FormatUint(uint64(castValue), 10)
-		default:
-			s = fmt.Sprint(castValue)
-		}
-
-		params[k] = s
+	for k, v := range secret.Data {
+		params[k] = fmt.Sprint(v)
 	}
 	return params, err
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -125,7 +125,7 @@ func (p *plugin) find(path string) (map[string]string, error) {
 		case uint64:
 			s = strconv.FormatUint(uint64(castValue), 10)
 		default:
-			s = fmt.Sprintf("%v", castValue)
+			s = fmt.Sprint(castValue)
 		}
 
 		params[k] = s


### PR DESCRIPTION
Consider the following data:
```
{
  "PORT": 3000,
  "EXISTS": true,
  "KEY": "randomString"
}
```

drone-vault fails to read `PORT` and `EXISTS` key. Instead of converting data to string, it skips the variable.

Docker image for testing: 
```
thatinfrastructureguy/drone-vault:v0.0.1
```

~Update: In order to build to pass, had to install ca-certificates and libgnutls30 . [Source](https://www.reddit.com/r/golang/comments/pz65s1/is_gopkgin_down_again/hfkso9g/)~