### PR TITLE
WIP: Add param wildcard

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ name: default
 
 steps:
 - name: build
-  image: golang:1.12
+  image: golang:1.17
   commands:
   - go test -v ./...
   - sh scripts/build.sh

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/drone/drone-vault
 
-go 1.12
+go 1.17
 
 require (
 	github.com/99designs/httpsignatures-go v0.0.0-20170731043157-88528bf4ca7e // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/joho/godotenv v1.2.0
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/onsi/gomega v1.4.2 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.0.6
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,6 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -84,8 +83,6 @@ github.com/onsi/gomega v1.4.2/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1Cpa
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -115,7 +112,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
-golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -131,7 +127,6 @@ golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/main.go
+++ b/main.go
@@ -12,8 +12,8 @@ import (
 	"github.com/drone/drone-go/plugin/secret"
 	"github.com/drone/drone-vault/plugin"
 	"github.com/drone/drone-vault/plugin/token"
-	"github.com/drone/drone-vault/plugin/token/kubernetes"
 	"github.com/drone/drone-vault/plugin/token/approle"
+	"github.com/drone/drone-vault/plugin/token/kubernetes"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/kelseyhightower/envconfig"

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -6,8 +6,8 @@ package plugin
 
 import (
 	"context"
-	"errors"
 	"encoding/json"
+	"errors"
 
 	"github.com/drone/drone-go/drone"
 	"github.com/drone/drone-go/plugin/secret"
@@ -43,7 +43,7 @@ func (p *plugin) Find(ctx context.Context, req *secret.Request) (*drone.Secret, 
 
 	var value string
 	if name == "*" {
-		jsonVal, err := json.Marshal(params) 
+		jsonVal, err := json.Marshal(params)
 		if err != nil {
 			return nil, errors.New("could not parse json")
 		}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -5,9 +5,9 @@
 package plugin
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
-	"bytes"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -30,7 +30,7 @@ var noContext = context.Background()
 //    export VAULT_TOKEN=dummy
 
 func TestPlugin(t *testing.T) {
-	fileSecret, _:= ioutil.ReadFile("testdata/secret.json") 
+	fileSecret, _ := ioutil.ReadFile("testdata/secret.json")
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write(fileSecret)
 	}))
@@ -44,7 +44,7 @@ func TestPlugin(t *testing.T) {
 	plugin := New(client)
 
 	// convert testdata/secret.json into mock return value
-  // used for asterisk selector test.
+	// used for asterisk selector test.
 	var jsonSecret map[string]map[string]interface{}
 	json.Unmarshal(fileSecret, &jsonSecret)
 	jsonSecretDataArr, _ := json.Marshal(filterStringData(jsonSecret["data"]))
@@ -114,7 +114,7 @@ func TestPlugin(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got, err := plugin.Find (noContext, &tc.Request)
+		got, err := plugin.Find(noContext, &tc.Request)
 		if err != nil {
 			t.Error(err)
 			return

--- a/plugin/testdata/secret.json
+++ b/plugin/testdata/secret.json
@@ -5,7 +5,7 @@
     "X-Drone-Repos":"octocat/*",
     "X-Drone-Events":"tag,push",
     "X-Drone-Branches":"master",
-    "timestmap": 2764800
+    "timestamp": 2764800
   },
   "lease_duration": 2764800,
   "renewable": false,

--- a/plugin/token/approle/approle_test.go
+++ b/plugin/token/approle/approle_test.go
@@ -129,7 +129,7 @@ func TestVaultApproleRenewHigherTTL(t *testing.T) {
 			data, _ = ioutil.ReadFile("testdata/renew_higher_ttl.json")
 		} else if r.URL.Path == "/v1/auth/approle/login" {
 			data, _ = ioutil.ReadFile("testdata/new_token.json")
-		} else{
+		} else {
 			t.Errorf("Invalid path, %v", r.URL.Path)
 		}
 		w.Write(data)
@@ -164,7 +164,7 @@ func TestVaultApproleRenewLowerTTL(t *testing.T) {
 			data, _ = ioutil.ReadFile("testdata/renew_lower_ttl.json")
 		} else if r.URL.Path == "/v1/auth/approle/login" {
 			data, _ = ioutil.ReadFile("testdata/new_token.json")
-		} else{
+		} else {
 			t.Errorf("Invalid path, %v", r.URL.Path)
 		}
 		w.Write(data)


### PR DESCRIPTION
Vault has the ability to generate temporary credentials from e.g. AWS IAM.

The current way of pulling secrets prevents the use of temporary credentials as you can only define one field from the secret to import into an environment variable. If you pull `AWS_ACCESS_KEY_ID`,  `AWS_ACCESS_KEY_ID` and `AWS_SESSION_TOKEN` from the same secret you will end up with 3 disconnected values.

This PR enables pulling the whole `data` object (only string values) from a secret (could be the `creds` endpoint of the AWS engine), enabling your pipeline step to parse and use the values itself.

Note that the asterisk has to be quoted for the web request to work.
```yaml
kind: secret
name: aws_credentials
get:
  path: aws/account/creds/role
  name: "*"
```

_**WIP**: Needs testing but would like to have the PR out for input._