### PR TITLE
feat: Disallow forks from getting secrets

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -17,22 +17,33 @@ import (
 
 // New returns a new secret plugin that sources secrets
 // from the AWS secrets manager.
-func New(client *api.Client) secret.Plugin {
+func New(client *api.Client, disallowForks bool) secret.Plugin {
 	return &plugin{
-		client: client,
+		client:        client,
+		disallowForks: disallowForks,
 	}
 }
 
 type plugin struct {
-	client *api.Client
+	client        *api.Client
+	disallowForks bool
 }
 
 func (p *plugin) Find(ctx context.Context, req *secret.Request) (*drone.Secret, error) {
+	// The Fork attribute will be empty on a branch build (e.g. master).
+	// Branch builds cannot be from a fork.
+	isFork := req.Build.Fork != "" && req.Build.Fork != req.Repo.Slug
+	forkRepo := ""
+	if isFork {
+		forkRepo = req.Build.Fork
+	}
+
 	logEvent := logrus.WithFields(logrus.Fields{
 		"event":  req.Build.Event,
 		"repo":   req.Repo.Slug,
 		"ref":    req.Build.Ref,
 		"secret": req.Path,
+		"fork":   forkRepo,
 	})
 
 	path := req.Path
@@ -52,7 +63,7 @@ func (p *plugin) Find(ctx context.Context, req *secret.Request) (*drone.Secret, 
 		return nil, errors.New("secret key not found")
 	}
 
-	// the user can filter out requets based on event type
+	// the user can filter out requests based on event type
 	// using the X-Drone-Events secret key. Check for this
 	// user-defined filter logic.
 	events := extractEvents(params)
@@ -62,7 +73,7 @@ func (p *plugin) Find(ctx context.Context, req *secret.Request) (*drone.Secret, 
 		return nil, errors.New(msg)
 	}
 
-	// the user can filter out requets based on repository
+	// the user can filter out requests based on repository
 	// using the X-Drone-Repos secret key. Check for this
 	// user-defined filter logic.
 	repos := extractRepos(params)
@@ -72,7 +83,7 @@ func (p *plugin) Find(ctx context.Context, req *secret.Request) (*drone.Secret, 
 		return nil, errors.New(msg)
 	}
 
-	// the user can filter out requets based on repository
+	// the user can filter out requests based on repository
 	// branch using the X-Drone-Branches secret key. Check
 	// for this user-defined filter logic.
 	branches := extractBranches(params)
@@ -82,13 +93,26 @@ func (p *plugin) Find(ctx context.Context, req *secret.Request) (*drone.Secret, 
 		return nil, errors.New(msg)
 	}
 
+	// the user can disallow fork builds using the
+	// X-Drone-Disallow-Forks secret key. Check for this
+	// user-defined filter logic.
+	disallowForks := p.disallowForks
+	if secretSetting := extractDisallowForks(params); secretSetting != nil {
+		disallowForks = *secretSetting
+	}
+	if disallowForks && isFork {
+		msg := "access denied: forks are not allowed"
+		logEvent.WithField("disallow_forks", disallowForks).Debug(msg)
+		return nil, errors.New(msg)
+	}
+
 	logEvent.Debug("secret matched and returned")
 
 	return &drone.Secret{
 		Name: name,
 		Data: value,
 		Pull: true, // always true. use X-Drone-Events to prevent pull requests.
-		Fork: true, // always true. use X-Drone-Events to prevent pull requests.
+		Fork: true, // always true. use X-Drone-Disallow-Forks to prevent secrets from forks.
 	}, nil
 }
 

--- a/plugin/util.go
+++ b/plugin/util.go
@@ -4,7 +4,10 @@
 
 package plugin
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+)
 
 // helper function extracts the branch filters from the
 // secret payload in key value format.
@@ -34,6 +37,18 @@ func extractEvents(params map[string]string) []string {
 	for key, value := range params {
 		if strings.EqualFold(key, "X-Drone-Events") {
 			return parseCommaSeparated(value)
+		}
+	}
+	return nil
+}
+
+// helper function extracts the fork filter from the
+// secret payload in key value format.
+func extractDisallowForks(params map[string]string) *bool {
+	for key, value := range params {
+		if strings.EqualFold(key, "X-Drone-Disallow-Forks") {
+			v, _ := strconv.ParseBool(value)
+			return &v // Allow non-truthy or non-falsey values are false
 		}
 	}
 	return nil


### PR DESCRIPTION
- Adds a global `DRONE_DISALLOW_FORKS` env variable to disallow forks from getting secrets
- Adds a secret-level override (`X-Drone-Disallow-Forks`) to allow or disallow a specific secret